### PR TITLE
Ensure consistent scroll-to-top behavior

### DIFF
--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const location = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location.pathname]);
+
+  return null;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,11 +2,13 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App.jsx";
+import ScrollToTop from "./components/ScrollToTop.jsx";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <BrowserRouter>
+      <ScrollToTop />
       <App />
     </BrowserRouter>
   </React.StrictMode>

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Link } from "react-router-dom";
 
 export default function Contact() {
@@ -16,11 +16,6 @@ export default function Contact() {
   const [status, setStatus] = useState('idle'); // idle, loading, success, error
   const [errorMessage, setErrorMessage] = useState('');
   const [validationErrors, setValidationErrors] = useState({});
-
-  // Scroll to top when component mounts
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, []);
 
   const validateForm = () => {
     const errors = {};


### PR DESCRIPTION
## Summary
- add a shared ScrollToTop component that resets scroll on each route change
- register the scroll restoration helper with the BrowserRouter so all links land at the top
- remove the contact page's custom scroll effect in favor of the centralized behaviour

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cf4512b4588330823bb57c00174814