### PR TITLE
Adjust header spacing for better mobile hero visibility

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -76,10 +76,10 @@ function Header() {
       } backdrop-blur bg-black text-white`}
     >
       <div className="mx-auto max-w-6xl px-4 sm:px-6">
-        <div className="flex h-28 items-center justify-between">
+        <div className="flex h-20 items-center justify-between md:h-28">
           {/* Left: Logo (desktop size 2x) */}
           <Link to="/" className="flex items-center gap-2 group">
-             <img src="/logo.png" alt="Dex Intelligence Inc." className="h-24 w-auto" />
+            <img src="/logo.png" alt="Dex Intelligence Inc." className="h-16 w-auto md:h-24" />
           </Link>
 
 


### PR DESCRIPTION
## Summary
- lower the fixed header height to h-20 on small screens while keeping md:h-28 for larger breakpoints
- scale the logo image to h-16 on mobile so it fits the shorter header while retaining the md sizing

## Testing
- npm run lint *(fails: legacy Netlify function files rely on CommonJS globals such as require/process)*
- Manually verified hero visibility at 390px-wide viewport via Playwright
- Manually checked desktop header layout at 1280px-wide viewport via Playwright

------
https://chatgpt.com/codex/tasks/task_e_68cf49ef5d7c83308289aa5659686553