### PR TITLE
Create shared economist content module and extend About page

### DIFF
--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
-import { Shield, Lock, FileCheck, Brain, Play } from 'lucide-react';
+import { Shield, Lock, FileCheck, Brain, Play, ShieldCheck } from 'lucide-react';
 import { TeamSection } from './Team.jsx';
+import { economistSupport, roadmap } from '../utils/content.js';
 
 export default function About() {
     return (
@@ -78,6 +79,59 @@ export default function About() {
               <p className="text-base text-gray-300 leading-relaxed transition-colors group-hover:text-gray-200">
                 Proprietary workflows ensure client data never enters public AI systems
               </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="mt-16">
+          <div className="rounded-3xl border border-white/10 bg-gradient-to-br from-brand/15 via-black/70 to-black/90 px-6 py-8 sm:px-8 sm:py-10">
+            <div className="mb-6">
+              <h2 className="text-3xl font-semibold text-white relative">
+                Your economist partners
+                <span className="absolute -bottom-2 left-0 h-1 w-16 bg-brand sm:w-20"></span>
+              </h2>
+              <p className="mt-6 text-base sm:text-lg text-gray-300 leading-relaxed">
+                Dex is founder-led by economists who stay embedded with every engagement. The team pairs real-world merger review
+                experience with rapid, platform-backed analysis so your strategy is grounded in trusted evidence.
+              </p>
+            </div>
+            <ul className="space-y-4">
+              {economistSupport.map((item) => (
+                <li key={item} className="flex gap-3 text-sm sm:text-base text-gray-200 leading-relaxed">
+                  <ShieldCheck className="h-5 w-5 flex-shrink-0 text-brand" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+            <Link
+              to="/team"
+              className="mt-8 inline-flex items-center justify-center rounded-full border border-brand/60 px-5 py-2 text-sm font-semibold text-brand transition hover:bg-brand hover:text-black"
+            >
+              Meet the team
+            </Link>
+          </div>
+        </section>
+
+        <section className="mt-12">
+          <div className="rounded-3xl border border-white/10 bg-gradient-to-br from-black/70 via-black/80 to-black/90 px-6 py-8 sm:px-8 sm:py-10">
+            <div className="mb-6">
+              <h2 className="text-2xl font-semibold text-white">Roadmap at a glance</h2>
+              <p className="mt-3 text-sm sm:text-base text-gray-300 leading-relaxed">
+                We are shipping quickly alongside design partners. Here's how the Dex Platform evolves over the next phases.
+              </p>
+            </div>
+            <div className="relative pl-6 sm:pl-8">
+              <span className="absolute left-2 top-0 h-full w-px bg-gradient-to-b from-brand/60 via-white/10 to-transparent" aria-hidden="true"></span>
+              <div className="space-y-6">
+                {roadmap.map((item) => (
+                  <div key={item.phase} className="relative pl-4">
+                    <span className="absolute -left-5 top-1 h-2.5 w-2.5 rounded-full border border-brand bg-black"></span>
+                    <p className="text-xs font-semibold uppercase tracking-[0.25em] text-brand/80">{item.phase}</p>
+                    <h3 className="mt-1 text-lg font-semibold text-white">{item.title}</h3>
+                    <p className="mt-1 text-sm text-gray-300 leading-relaxed">{item.description}</p>
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
         </section>

--- a/src/pages/Products.jsx
+++ b/src/pages/Products.jsx
@@ -11,6 +11,7 @@ import {
     Play,
     Download,
 } from 'lucide-react';
+import { economistSupport, roadmap } from '../utils/content.js';
 
 export default function Products() {
 
@@ -80,33 +81,6 @@ export default function Products() {
                 'Machine learning tools harmonize diverse datasets, including customer location analysis for precise market definition.',
                 'Advanced economic modeling with gravity models and sophisticated concentration analysis for complex markets.',
             ],
-        },
-    ];
-
-    const economistSupport = [
-        'Expert review of automated analysis by economists with hands-on merger and litigation experience.',
-        'Strategic guidance on market definition, competitive effects, and remedy design tailored to your matter.',
-        'Collaborative case planning ensuring economic analysis aligns with legal strategy and timeline.',
-    ];
-
-    const roadmap = [
-        {
-            phase: 'Phase 1 · Q4 2025',
-            title: 'Deliver best-in-class local area analysis',
-            description:
-                'Market Mapper v1 in live beta with design partners, generating regulator-ready evidence packages on-demand.',
-        },
-        {
-            phase: 'Phase 2 · Q2 2026',
-            title: 'Add sales-based market share intelligence',
-            description:
-                'Blend client transaction data with Dex benchmarks to automate market share and concentration analysis and rapid remedy evaluation.',
-        },
-        {
-            phase: 'Phase 3 · Q4 2026 – 2027',
-            title: 'Scale to mature econometrics',
-            description:
-                'Full econometric suite for complex merger reviews and antitrust litigation, built on the same trusted workflows and data fabric.',
         },
     ];
 

--- a/src/utils/content.js
+++ b/src/utils/content.js
@@ -1,0 +1,26 @@
+export const economistSupport = [
+  'Expert review of automated analysis by economists with hands-on merger and litigation experience.',
+  'Strategic guidance on market definition, competitive effects, and remedy design tailored to your matter.',
+  'Collaborative case planning ensuring economic analysis aligns with legal strategy and timeline.',
+];
+
+export const roadmap = [
+  {
+    phase: 'Phase 1 · Q4 2025',
+    title: 'Deliver best-in-class local area analysis',
+    description:
+      'Market Mapper v1 in live beta with design partners, generating regulator-ready evidence packages on-demand.',
+  },
+  {
+    phase: 'Phase 2 · Q2 2026',
+    title: 'Add sales-based market share intelligence',
+    description:
+      'Blend client transaction data with Dex benchmarks to automate market share and concentration analysis and rapid remedy evaluation.',
+  },
+  {
+    phase: 'Phase 3 · Q4 2026 – 2027',
+    title: 'Scale to mature econometrics',
+    description:
+      'Full econometric suite for complex merger reviews and antitrust litigation, built on the same trusted workflows and data fabric.',
+  },
+];


### PR DESCRIPTION
## Summary
- move the economist support bullets and roadmap timeline data into a shared `src/utils/content.js` module and import it on Products and About pages
- expand the About page with a founder-led economist partners section and concise roadmap overview that reuse the shared content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0aab9577c83308a4499a56a3b456a